### PR TITLE
Fix #6 blend mode multiply not working on lower API versions.

### DIFF
--- a/color-picker/src/main/java/com/godaddy/android/colorpicker/SaturationValueArea.kt
+++ b/color-picker/src/main/java/com/godaddy/android/colorpicker/SaturationValueArea.kt
@@ -68,7 +68,7 @@ internal fun SaturationValueArea(
         }
     ) {
         drawRect(blackGradientBrush)
-        drawRect(currentColorGradientBrush, blendMode = BlendMode.Multiply)
+        drawRect(currentColorGradientBrush, blendMode = BlendMode.Modulate)
         drawRect(Color.Gray, style = Stroke(0.5.dp.toPx()))
 
         drawCircleSelector(currentColor)


### PR DESCRIPTION
As per #6, older Android APIs and Desktop Compose don't seem to support `BlendMode.Multiply`. This is a small PR to switch to `BlendMode.Modulate` as that works for this specific scenario. Thanks to @HuixingWong for fixing in #4, just bringing it over to make a release before multiplatform changes. 