### PR TITLE
Update library dependencies.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,6 @@
 
 plugins {
-    id("org.jetbrains.compose") version "1.0.1"
+    id("org.jetbrains.compose") version "1.1.0"
     id("com.android.application")
     kotlin("android")
 }
@@ -11,21 +11,22 @@ version = "1.0"
 
 dependencies {
     implementation(project(":color-picker"))
-    implementation ("androidx.activity:activity-compose:1.4.0")
-    implementation("com.google.android.material:material:1.5.0")
-    implementation("androidx.navigation:navigation-runtime-ktx:2.3.5")
-    implementation("androidx.navigation:navigation-compose:2.4.0-rc01")
+    implementation ("androidx.activity:activity-compose:1.5.1")
+    implementation("com.google.android.material:material:1.6.1")
+    implementation("androidx.navigation:navigation-runtime-ktx:2.5.1")
+    implementation("androidx.navigation:navigation-compose:2.5.1")
 }
 
 android {
-    compileSdk = 31
+    compileSdk = 32
     defaultConfig {
         applicationId = "com.godaddy.android.colorpicker"
         minSdk = 21
-        targetSdk = 31
+        targetSdk = 32
         versionCode = 1
         versionName = "1.0"
     }
+
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8

--- a/app/src/main/java/com/godaddy/android/colorpicker/theme/Components.kt
+++ b/app/src/main/java/com/godaddy/android/colorpicker/theme/Components.kt
@@ -1,3 +1,4 @@
+// ktlint-disable filename
 package com.godaddy.android.colorpicker.theme
 
 import androidx.compose.material.Icon

--- a/app/src/main/java/com/godaddy/android/colorpicker/theme/ComposeColorPickerTheme.kt
+++ b/app/src/main/java/com/godaddy/android/colorpicker/theme/ComposeColorPickerTheme.kt
@@ -30,7 +30,7 @@ private val LightColorPalette = lightColors(
 @Composable
 fun ComposeColorPickerTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
-    content: @Composable() () -> Unit
+    content: @Composable () -> Unit
 ) {
     val colors = if (darkTheme) {
         DarkColorPalette

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,12 +8,12 @@ buildscript {
     }
     dependencies {
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10")
-        classpath("com.android.tools.build:gradle:7.0.4")
+        classpath("com.android.tools.build:gradle:7.2.2")
     }
 }
 
 group = "com.godaddy"
-version = "0.3.0"
+version = "0.4.2"
 
 allprojects {
     repositories {
@@ -24,7 +24,7 @@ allprojects {
 }
 
 plugins {
-    id("com.diffplug.spotless") version "6.2.0"
+    id("com.diffplug.spotless") version "6.10.0"
 }
 
 apply("${project.rootDir}/gradle/spotless.gradle")

--- a/color-picker/build.gradle.kts
+++ b/color-picker/build.gradle.kts
@@ -3,7 +3,7 @@ import org.jetbrains.compose.compose
 plugins {
     kotlin("multiplatform")
     id("org.jetbrains.dokka") version "1.6.10"
-    id("org.jetbrains.compose") version "1.0.1"
+    id("org.jetbrains.compose") version "1.1.0"
     id("com.android.library")
     id("maven-publish")
     id("signing")
@@ -35,8 +35,8 @@ kotlin {
         }
         val androidMain by getting {
             dependencies {
-                api("androidx.appcompat:appcompat:1.4.0")
-                api("androidx.core:core-ktx:1.7.0")
+                api("androidx.appcompat:appcompat:1.5.0")
+                api("androidx.core:core-ktx:1.8.0")
             }
         }
         val androidTest by getting {

--- a/color-picker/src/androidMain/kotlin/com/godaddy/android/colorpicker/HsvColorExt.kt
+++ b/color-picker/src/androidMain/kotlin/com/godaddy/android/colorpicker/HsvColorExt.kt
@@ -1,3 +1,4 @@
+// ktlint-disable filename
 package com.godaddy.android.colorpicker
 
 /**

--- a/color-picker/src/commonMain/kotlin/com/godaddy/android/colorpicker/AlphaBar.kt
+++ b/color-picker/src/commonMain/kotlin/com/godaddy/android/colorpicker/AlphaBar.kt
@@ -33,11 +33,11 @@ internal fun AlphaBar(
     currentColor: HsvColor,
     onAlphaChanged: (Float) -> Unit
 ) {
-
     val currentColorToAlphaBrush = remember(currentColor) {
         Brush.horizontalGradient(
             listOf(
-                currentColor.copy(alpha = 1.0f).toColor(), Color(0x00ffffff)
+                currentColor.copy(alpha = 1.0f).toColor(),
+                Color(0x00ffffff)
             )
         )
     }
@@ -67,7 +67,6 @@ internal fun AlphaBar(
                 }
             }
     ) {
-
         clipRect {
             drawCheckeredBackground()
         }

--- a/color-picker/src/commonMain/kotlin/com/godaddy/android/colorpicker/HsvColor.kt
+++ b/color-picker/src/commonMain/kotlin/com/godaddy/android/colorpicker/HsvColor.kt
@@ -48,7 +48,7 @@ data class HsvColor(
             this.copy(hue = (hue + 150) % 360, saturation = (saturation - 0.05f).coerceIn(0.0f, 1f), value = (value - 0.3f).coerceIn(0.0f, 1f)),
             this.copy(hue = (hue + 210) % 360, saturation = (saturation - 0.05f).coerceIn(0.0f, 1f), value = (value - 0.3f).coerceIn(0.0f, 1f)),
             this.copy(hue = (hue + 150) % 360), // actual
-            this.copy(hue = (hue + 210) % 360), // actual
+            this.copy(hue = (hue + 210) % 360) // actual
         )
     }
 
@@ -57,7 +57,7 @@ data class HsvColor(
             this.copy(hue = (hue + 120) % 360, saturation = (saturation - 0.05f).coerceIn(0.0f, 1f), value = (value - 0.3f).coerceIn(0.0f, 1f)),
             this.copy(hue = (hue + 120) % 360),
             this.copy(hue = (hue + 240) % 360, saturation = (saturation - 0.05f).coerceIn(0.0f, 1f), value = (value - 0.3f).coerceIn(0.0f, 1f)),
-            this.copy(hue = (hue + 240) % 360),
+            this.copy(hue = (hue + 240) % 360)
         )
     }
 
@@ -66,7 +66,7 @@ data class HsvColor(
             this.copy(saturation = (saturation + 0.2f).coerceIn(0.0f, 1f)), // bonus one
             this.copy(hue = (hue + 90) % 360),
             this.copy(hue = (hue + 180) % 360),
-            this.copy(hue = (hue + 270) % 360),
+            this.copy(hue = (hue + 270) % 360)
         )
     }
 
@@ -75,7 +75,7 @@ data class HsvColor(
             this.copy(hue = (hue + 30) % 360),
             this.copy(hue = (hue + 60) % 360),
             this.copy(hue = (hue + 90) % 360),
-            this.copy(hue = (hue + 120) % 360),
+            this.copy(hue = (hue + 120) % 360)
         )
     }
 
@@ -84,7 +84,7 @@ data class HsvColor(
             this.copy(saturation = (saturation + 0.2f).mod(1f)),
             this.copy(saturation = (saturation + 0.4f).mod(1f)),
             this.copy(saturation = (saturation + 0.6f).mod(1f)),
-            this.copy(saturation = (saturation + 0.8f).mod(1f)),
+            this.copy(saturation = (saturation + 0.8f).mod(1f))
         )
     }
 
@@ -93,7 +93,7 @@ data class HsvColor(
             this.copy(value = (value - 0.10f).mod(1.0f).coerceAtLeast(0.2f)),
             this.copy(value = (value + 0.55f).mod(1.0f).coerceAtLeast(0.55f)),
             this.copy(value = (value + 0.30f).mod(1.0f).coerceAtLeast(0.3f)),
-            this.copy(value = (value + 0.05f).mod(1.0f).coerceAtLeast(0.2f)),
+            this.copy(value = (value + 0.05f).mod(1.0f).coerceAtLeast(0.2f))
         )
     }
 
@@ -131,7 +131,7 @@ data class HsvColor(
                 color.red,
                 color.green,
                 color.blue,
-                color.alpha,
+                color.alpha
             ).toHSV().toColor()
         }
 

--- a/color-picker/src/commonMain/kotlin/com/godaddy/android/colorpicker/HueBar.kt
+++ b/color-picker/src/commonMain/kotlin/com/godaddy/android/colorpicker/HueBar.kt
@@ -68,7 +68,7 @@ private fun getRainbowColors(): List<Color> {
         Color(0xFF80FF00),
         Color(0xFFFFFF00),
         Color(0xFFFF8000),
-        Color(0xFFFF0000),
+        Color(0xFFFF0000)
     )
 }
 

--- a/color-picker/src/commonMain/kotlin/com/godaddy/android/colorpicker/harmony/BrightnessBar.kt
+++ b/color-picker/src/commonMain/kotlin/com/godaddy/android/colorpicker/harmony/BrightnessBar.kt
@@ -15,7 +15,8 @@ internal fun BrightnessBar(
 ) {
     Slider(
         modifier = modifier,
-        value = currentColor.value, onValueChange = {
+        value = currentColor.value,
+        onValueChange = {
             onValueChange(it)
         },
         colors = SliderDefaults.colors(

--- a/color-picker/src/commonMain/kotlin/com/godaddy/android/colorpicker/harmony/ColorWheel.kt
+++ b/color-picker/src/commonMain/kotlin/com/godaddy/android/colorpicker/harmony/ColorWheel.kt
@@ -30,7 +30,7 @@ internal fun ColorWheel(
             HsvColor(180f, saturation, value, alpha),
             HsvColor(240f, saturation, value, alpha),
             HsvColor(300f, saturation, value, alpha),
-            HsvColor(360f, saturation, value, alpha),
+            HsvColor(360f, saturation, value, alpha)
         ).map {
             it.toColor()
         }

--- a/color-picker/src/commonMain/kotlin/com/godaddy/android/colorpicker/harmony/HarmonyColorPicker.kt
+++ b/color-picker/src/commonMain/kotlin/com/godaddy/android/colorpicker/harmony/HarmonyColorPicker.kt
@@ -46,7 +46,6 @@ fun HarmonyColorPicker(
                 .fillMaxHeight()
                 .fillMaxWidth()
         ) {
-
             val hsvColor = remember { mutableStateOf(HsvColor.from(color)) }
 
             HarmonyColorPickerWithMagnifiers(

--- a/desktop/build.gradle.kts
+++ b/desktop/build.gradle.kts
@@ -3,7 +3,7 @@ import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 
 plugins {
     kotlin("multiplatform")
-    id("org.jetbrains.compose") version "1.0.1"
+    id("org.jetbrains.compose") version "1.1.0"
 }
 
 group = "com.godaddy"

--- a/desktop/src/jvmMain/kotlin/Main.kt
+++ b/desktop/src/jvmMain/kotlin/Main.kt
@@ -36,7 +36,8 @@ fun main() = application {
 
                     val currentColorPicker = remember { mutableStateOf(ColorPicker.CLASSIC) }
                     TabRow(
-                        currentColorPicker.value.ordinal, tabs = {
+                        currentColorPicker.value.ordinal,
+                        tabs = {
                             Text(
                                 "Classic Picker",
                                 modifier =

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Wed Oct 13 13:34:56 SAST 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists


### PR DESCRIPTION
Update several dependencies used in the library and samples 
* compose up to v1.1.1
* gradle wrapper up to 7.5.1
* spotless plugin up to 6.10.0
* androidx.appcompat:appcompat up to 1.5.0
* androidx.activity:activity-compose up to 1.5.1
* com.google.android.material:material up to 1.6.1
* androidx.navigation:navigation-runtime-ktx up to 2.5.1
* androidx.navigation:navigation-compose up to 2.5.1